### PR TITLE
Implement equalsValue with targetType

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/mockmvc/extensions/mockMvcAssertions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mockmvc/extensions/mockMvcAssertions.kt
@@ -18,10 +18,9 @@ fun ResultActions.statusIsOk(): ResultActions =
     this.andExpect(status().isOk)
 
 data class JsonPathEquals(val expression: String, val resultActions: ResultActions) {
-    fun equalsValue(value: Any): ResultActions = resultActions.andExpect(jsonPath(expression, Matchers.equalTo(value)))
 
-    fun <T> equalsValue(value: T, targetType: Class<T>): ResultActions =
-        resultActions.andExpect(jsonPath(expression, Matchers.equalTo<T>(value), targetType))
+    inline fun <reified T> equalsValue(value: T): ResultActions =
+        resultActions.andExpect(jsonPath(expression, Matchers.equalTo<T>(value), T::class.java))
 
     fun equalsObject(
         expected: Any,

--- a/src/main/kotlin/no/skatteetaten/aurora/mockmvc/extensions/mockMvcAssertions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mockmvc/extensions/mockMvcAssertions.kt
@@ -20,6 +20,9 @@ fun ResultActions.statusIsOk(): ResultActions =
 data class JsonPathEquals(val expression: String, val resultActions: ResultActions) {
     fun equalsValue(value: Any): ResultActions = resultActions.andExpect(jsonPath(expression, Matchers.equalTo(value)))
 
+    fun <T> equalsValue(value: T, targetType: Class<T>): ResultActions =
+        resultActions.andExpect(jsonPath(expression, Matchers.equalTo<T>(value), targetType))
+
     fun equalsObject(
         expected: Any,
         objectMapper: ObjectMapper = TestObjectMapperConfigurer.objectMapper

--- a/src/test/kotlin/no/skatteetaten/aurora/mockmvc/extensions/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mockmvc/extensions/ControllerIntegrationTest.kt
@@ -56,7 +56,7 @@ class ControllerIntegrationTest {
         ) {
             statusIsOk()
                 .responseJsonPath("$.key1").equalsValue("123")
-                .responseJsonPath("$.key1").equalsValue(123, Int::class.java)
+                .responseJsonPath("$.key1").equalsValue<Long>(123)
                 .responseJsonPath("$.key2").isEmpty()
                 .responseJsonPath("$.success").isFalse()
         }

--- a/src/test/kotlin/no/skatteetaten/aurora/mockmvc/extensions/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mockmvc/extensions/ControllerIntegrationTest.kt
@@ -56,6 +56,7 @@ class ControllerIntegrationTest {
         ) {
             statusIsOk()
                 .responseJsonPath("$.key1").equalsValue("123")
+                .responseJsonPath("$.key1").equalsValue(123, Int::class.java)
                 .responseJsonPath("$.key2").isEmpty()
                 .responseJsonPath("$.success").isFalse()
         }


### PR DESCRIPTION
This adds misisng feature of declaring expected type in jsonpath method, introduced to Spring by https://github.com/spring-projects/spring-framework/pull/23141

Example use case:
[Stack Overflow](https://stackoverflow.com/questions/37996419/how-to-force-andexpectjsonpath-to-return-long-long-instead-int-for-int-num)